### PR TITLE
Support shallow cloning

### DIFF
--- a/app/meticulous/_github.py
+++ b/app/meticulous/_github.py
@@ -99,7 +99,7 @@ def checkout(repo, target):
     git = local["/usr/bin/git"]
     with local.cwd(str(target)):
         _ = (
-            git["clone", f"ssh://git@github.com/{user_org}/{repo}", str(clone_target)]
+            git["clone", "--depth=3", f"ssh://git@github.com/{user_org}/{repo}", str(clone_target)]
             & FG
         )
 

--- a/app/meticulous/_github.py
+++ b/app/meticulous/_github.py
@@ -99,7 +99,12 @@ def checkout(repo, target):
     git = local["/usr/bin/git"]
     with local.cwd(str(target)):
         _ = (
-            git["clone", "--depth=3", f"ssh://git@github.com/{user_org}/{repo}", str(clone_target)]
+            git[
+                "clone",
+                "--depth=3",
+                f"ssh://git@github.com/{user_org}/{repo}",
+                str(clone_target),
+            ]
             & FG
         )
 

--- a/app/meticulous/newsfragments/25.feature
+++ b/app/meticulous/newsfragments/25.feature
@@ -1,0 +1,1 @@
+Use shallow clone for repositories to improve speed and reduce disk usage.

--- a/app/meticulous/newsfragments/25.feature
+++ b/app/meticulous/newsfragments/25.feature
@@ -1,1 +1,1 @@
-Use shallow clone for repositories to improve speed and reduce disk usage.
+Use shallow clone for repositories to improve speed and reduce disk usage. Thanks to @katrinleinweber.


### PR DESCRIPTION
Hello & thanks for this tool!

I'd like to test-drive it, but wasn't yet sure how to and where to read up on the functionality.

Still I'd already like to suggest to use shallow cloning, since "locat[ing] typos" probably does not mean a proof-reader routinely needs to dive into a projects commit history. According to [Atlassian](https://www.atlassian.com/git/tutorials/big-repositories) & [Linux Hint](https://linuxhint.com/git-shallow-clone-and-clone-depth/), this both speeds up the cloning process & reduces the amount of locally required storage space for the clone.

<!--
Thank you for your contribution to the meticulous repository.
Your code will need to pass the automated checks before merging.
Before submitting this PR, please make sure the follow checks are done if
applicable, also if they are applicable move them out of this comment into the
main PR text body:
-->

- [ ] Unit tests added (haven't had much experience with those in Python, sorry)
- [ ] Documentations updated with the change ([not yet drafted](https://github.com/timgates42/meticulous/tree/e0f31dc07881d8d953a2312ed875ad00d34797f0/docs)?)
- [ ] Towncrier news fragment added (new to me)

I'll add these things, if we generally agree about this change suggestion or how to implement it more elegantly.

Cheers!