### PR TITLE
Make first option to just submit a PR.

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -13,4 +13,3 @@
 - way of running auto process on manually added repo (json not exists)
 - javascript
 - cpp
-- default to just a commit not issue + pr  Issue #55

--- a/app/meticulous/_process.py
+++ b/app/meticulous/_process.py
@@ -244,12 +244,9 @@ def get_pr_or_issue_choices(reponame, repodirpath):  # pylint: disable=too-many-
         print(f"{reponame} {'HAS' if has_path else 'does not have'}" f" {path}")
         if has_path:
             choices[f"show {path}"] = (show_path, path)
-    repo_disables_issues = (repodirpath / no_issues).exists()
-    if repo_disables_issues:
-        choices["make a commit"] = (make_a_commit, False)
-    else:
-        choices["make a full issue"] = (make_issue, True)
-        choices["make a short issue"] = (make_issue, False)
+    choices["make a commit"] = (make_a_commit, False)
+    choices["make a full issue"] = (make_issue, True)
+    choices["make a short issue"] = (make_issue, False)
     has_issue = (repodirpath / issue).exists()
     if has_issue:
         choices["submit issue"] = (submit_issue, None)


### PR DESCRIPTION
Rather than creating either a full or short issue for every typo, make
the first option to create just a PR. If the contribution guide requests
creating an issue then the full and short issue options are still
available in the menu.

Closes #55

<!--
Thank you for your contribution to the meticulous repository.
Your code will need to pass the automated checks before merging.
Before submitting this PR, please make sure the follow checks are done if
applicable, also if they are applicable move them out of this comment into the
main PR text body:
- [x] Unit tests added
- [x] Documentations updated with the change
- [x] Towncrier news fragment added
-->
