### PR TITLE
Fix spelling in note left in projects

### DIFF
--- a/docs/NOTE.md
+++ b/docs/NOTE.md
@@ -1,13 +1,13 @@
 This repository produces semi-automated pull-requests and stamps them with a
 reference to this note to be transparent about the automation.
 
-This reference is not intended to be advertising so if you are upset about the
-reference please request the comment be updated to remove the reference.
+This reference is not intended to be advertising, so if you are upset about the
+reference, please request the comment be updated to remove the reference.
 
-The automation in this repository runs a spell checker over a repository and
+The automation in this repository runs a spell checker over a repository,
 highlights a list of potential spelling errors for the user to select and
-correct, it then prepares a pull request. The spelling errors have been reviewed
-by a human but mistakes can be made. The most frequent mistake is fixing
+correct, and then prepares a pull request. The spelling errors have been reviewed
+by a human, but mistakes can be made. The most frequent mistake is fixing
 spelling mistakes in versioned source files from dependent libraries. If this
-happens please accept my appologies and if possible feel free to add a comment to
-the pull request and close it.
+happens, please accept my apologies, and if possible, feel free to add a comment
+to the pull request and close it.


### PR DESCRIPTION
In one of those very sweet cases of irony, the note had a spelling mistake ("appologies" instead of "apologies"). I took the chance to clean up the grammar a bit while I was fixing that, too.