### PR TITLE
Switch back to directly creating PRs

### DIFF
--- a/app/meticulous/_submit.py
+++ b/app/meticulous/_submit.py
@@ -22,6 +22,12 @@ from meticulous._storage import get_multi_repo
 from meticulous._summary import display_and_check_files
 from meticulous._util import get_editor
 
+# Change in GitHub CI policy -
+# https://github.blog/2021-04-22-github-actions-update-helping-maintainers-combat-bad-actors/
+# pointed out in https://github.com/translate/translate/issues/4382
+# no need to create issues first
+CREATE_ISSUE_FIRST = False
+
 
 def get_note(kind, pr_url=None):
     """
@@ -226,7 +232,7 @@ def issue_and_branch_for(reponame, repository_saves_multi):
     repodir = reposave["repodir"]
     repodirpath = Path(repodir)
     no_issues_path = repodirpath / no_issues
-    if no_issues_path.is_file():
+    if no_issues_path.is_file() or not CREATE_ISSUE_FIRST:
         plain_pr_for(reponame, repository_saves_multi)
         return
     make_a_commit_multi(reponame, repository_saves_multi, False)


### PR DESCRIPTION
<!--
Thank you for your contribution to the meticulous repository.
Your code will need to pass the automated checks before merging.
Before submitting this PR, please make sure the follow checks are done if
applicable, also if they are applicable move them out of this comment into the
main PR text body:
- [x] Unit tests added
- [x] Documentations updated with the change
- [x] Towncrier news fragment added
-->
 
As pointed out in https://github.com/translate/translate/issues/4382 - creating an Issue looks to be mostly unnecessary now as quite a lot of repositories have switched to GitHub actions and CI requires a maintainers approval to start. 